### PR TITLE
Update to latest Burst compiler

### DIFF
--- a/unity/Packages/manifest.json
+++ b/unity/Packages/manifest.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "com.unity.ads": "2.0.8",
     "com.unity.analytics": "3.3.2",
-    "com.unity.burst": "1.0.0",
+    "com.unity.burst": "1.5.4",
     "com.unity.collab-proxy": "1.2.16",
     "com.unity.package-manager-ui": "2.1.2",
     "com.unity.purchasing": "2.0.6",


### PR DESCRIPTION
Received report that Burst 1.0.0 was producing warnings. I couldn't reproduce locally, but latest seems to work fine for me and the reporting user.